### PR TITLE
bugfix around this error: local variable 'failure_log' referenced before assignment

### DIFF
--- a/scripts/theorem.py
+++ b/scripts/theorem.py
@@ -200,7 +200,8 @@ class Theorem(object):
         for theorem in self.variations:
             t_node = etree.Element('theorem')
             ts_node.append(t_node)
-            if theorem.failure_log is None:
+            failure_log = theorem.failure_log
+            if failure_log is None:
                 _, failure_log = theorem.prove_debug()
             t_node.set('inference_result', theorem.result_simple)
             t_node.set('is_negated', str(theorem.is_negated))


### PR DESCRIPTION
HI. 
FIrst of all, thank you very much for creating such a wonderful library(and articles too).  
I don't know you are accepting PR or not, anyways I send here.  
  
When I executed:  
```
./en/rte_en_mp_any.sh en/sample_en.txt en/semantic_templates_en_emnlp2015.yaml
```
I got error log like this:
```
ERROR:root:An error occurred: local variable 'failure_log' referenced before assignment
```
in `en_results/sample_en.txt.***.err` files.  

(and as a result of this error, judgement become 'unknown' always.)  
I investigated and found the cause in theorem.py, so fix it.
Thanks.